### PR TITLE
Fixed bug causing non-removal of bogus wrapper

### DIFF
--- a/plugins/raw.rb
+++ b/plugins/raw.rb
@@ -8,7 +8,7 @@ module TemplateWrapper
   end
   # This must be applied after the
   def self.unwrap(input)
-    input.gsub /<div class='bogus-wrapper'><notextile>(.+?)<\/notextile><\/div>/m do
+    input.gsub /<div class=['"]bogus-wrapper['"]><notextile>(.+?)<\/notextile><\/div>/m do
       $1
     end
   end


### PR DESCRIPTION
Could have been an issue with Kramdown specifically, but the single quotes were being turned into double quotes, causing the regex not to match.